### PR TITLE
Replace ftx api with binance api

### DIFF
--- a/src/eth-prices/eth_prices.ts
+++ b/src/eth-prices/eth_prices.ts
@@ -4,7 +4,7 @@ import * as DateFnsAlt from "../date_fns_alt.js";
 import { JsTimestamp } from "../date_fns_alt.js";
 import { sql, sqlT, sqlTVoid } from "../db.js";
 import * as Duration from "../duration.js";
-import * as EthPricesFtx from "./ftx.js";
+import * as EthPricesBinance from "./binance.js";
 import { E, flow, O, pipe, T, TE } from "../fp.js";
 import * as Log from "../log.js";
 
@@ -44,7 +44,7 @@ const getCachedPrice = (dt: Date) =>
 
 const getFreshPrice = (dt: Date) =>
   pipe(
-    EthPricesFtx.getPriceByDate(dt),
+    EthPricesBinance.getPriceByDate(dt),
     TE.chainFirstIOK((historicPrice) => () => {
       priceByMinute.set(
         DateFns.getTime(historicPrice.timestamp),
@@ -82,7 +82,7 @@ export const storePrice = (ethPrice: EthPrice) =>
 
 export const storeCurrentEthPrice = () =>
   pipe(
-    EthPricesFtx.getPriceByDate(DateFns.startOfMinute(new Date())),
+    EthPricesBinance.getPriceByDate(DateFns.startOfMinute(new Date())),
     TE.chainFirstIOK((price) => () => {
       Log.debug(
         `stored price: ${price.ethusd}, date: ${price.timestamp.toISOString()}`,
@@ -143,7 +143,7 @@ export const getEthPrice = (
     TE.mapLeft((e) => {
       if (e instanceof PriceTooOldError) {
         Log.error(
-          "DB did not have a fresh enough eth price, falling back to FTX",
+          "DB did not have a fresh enough eth price, falling back to Binance",
         );
       }
 

--- a/src/reanalyze_eth_prices.ts
+++ b/src/reanalyze_eth_prices.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 import makeEta from "simple-eta";
 import * as Blocks from "./blocks/blocks.js";
 import { sql } from "./db.js";
-import * as EthPricesFtx from "./eth-prices/ftx.js";
+import * as EthPricesBinance from "./eth-prices/binance.js";
 import { A, E, O, pipe, TOAlt } from "./fp.js";
 import * as Log from "./log.js";
 
@@ -66,7 +66,7 @@ const logProgress = _.throttle(() => {
 }, 8000);
 
 while (nextDateToFetch !== undefined) {
-  const ePrices = await EthPricesFtx.getFtxPrices(
+  const ePrices = await EthPricesBinance.getBinancePrices(
     nextDateToFetch,
     DateFns.addMinutes(nextDateToFetch, 1500),
   )();

--- a/src/scripts/add_missing_prices.ts
+++ b/src/scripts/add_missing_prices.ts
@@ -4,7 +4,7 @@ import makeEta from "simple-eta";
 import * as Blocks from "../blocks/blocks.js";
 import { sql, sqlTVoid } from "../db.js";
 import { EthPrice } from "../eth-prices/eth_prices.js";
-import * as EthPricesFtx from "../eth-prices/ftx.js";
+import * as EthPricesBinance from "../eth-prices/binance.js";
 import * as ExecutionNode from "../execution_node.js";
 import { E, pipe, RA, T, TE } from "../fp.js";
 import * as Log from "../log.js";
@@ -65,11 +65,11 @@ while (nextDateToCheck.getTime() <= Date.now()) {
 
     await pipe(
       missingTimestamps,
-      T.traverseSeqArray((dt) => pipe(EthPricesFtx.getPriceByDate(dt))),
+      T.traverseSeqArray((dt) => pipe(EthPricesBinance.getPriceByDate(dt))),
       T.map((ePrices) => {
         const error = ePrices.find(
           (ePrice) =>
-            E.isLeft(ePrice) && !(ePrice instanceof EthPricesFtx.PriceNotFound),
+            E.isLeft(ePrice) && !(ePrice instanceof EthPricesBinance.PriceNotFound),
         );
 
         if (error) {


### PR DESCRIPTION
While trying tog et a development version of the server running on my local machine I noticed that the code still uses the ftx api (which is down afaik) to get eth prices, so I swapped it out for the binance api.

I'm a bit surprised though, since this should have produced issues in production by now, no ? Maybe I'm missing something here ?🤔