### PR TITLE
Performance optimization block queries

### DIFF
--- a/src/time_frames.ts
+++ b/src/time_frames.ts
@@ -79,17 +79,3 @@ export const secondsFromTimeFrame = (timeFrame: TimeFrameNext) => {
       return DateFns.differenceInSeconds(new Date(), londonHardForkBlockDate);
   }
 };
-
-export const sqlQueryFromTimeFrame = (timeFrame: TimeFrameNext) => {
-    if (timeFrame == "since_merge" || timeFrame == "since_burn") {
-      return `number >= ${
-        timeFrame == "since_merge"
-          ? mergeBlockNumber
-          : londonHardForkBlockNumber
-      }`;
-    } else {
-      return `mined_at >= NOW() - ${intervalSqlMapNext[timeFrame]}::interval`;
-    }
-}
-
-


### PR DESCRIPTION
I noticed that we sometimes get the latest block for a time frame from the db just to feed it back into another query that could be using the original condition (i.e. `mined_at >= now() - inteval`) to limit the analysis to the requested range.

In the two cases where this was the case I changed the code accordingly, which should hopefully improve performance since we eliminate one sql query per time frame.

Please note that I haven't done any performance testing on this. Also please lmk if I should add any unitests for this (unsure what the current testing policy is for this repo).
