### PR TITLE
Test script to analyze only fixed number of blocks

### DIFF
--- a/src/blocks/blocks.ts
+++ b/src/blocks/blocks.ts
@@ -186,7 +186,7 @@ export const storeBlock = async (
   block: BlockNodeV2,
   transactionReceipts: Transactions.TransactionReceiptV1[],
   ethPrice: number,
-  force: boolean = false,
+  force = false,
 ): Promise<void> => {
   const transactionSegments =
     Transactions.segmentTransactions(transactionReceipts);

--- a/src/blocks/sync.ts
+++ b/src/blocks/sync.ts
@@ -7,7 +7,7 @@ import * as Transactions from "../transactions.js";
 import * as Blocks from "./blocks.js";
 import { rollbackToIncluding } from "./new_head.js";
 
-export const syncBlock = async (blockNumber: number, skipParentCheck: boolean = false): Promise<void> => {
+export const syncBlock = async (blockNumber: number, skipParentCheck = false): Promise<void> => {
   Log.info(`syncing block: ${blockNumber}`);
   const block = await pipe(
     Blocks.getBlockSafe(blockNumber),

--- a/src/scripts/analyze_fixed_number_of_blocks.ts
+++ b/src/scripts/analyze_fixed_number_of_blocks.ts
@@ -1,4 +1,3 @@
-import Koa from "koa";
 import * as Blocks from "../blocks/blocks.js";
 import * as BlocksNewBlock from "../blocks/new_head.js";
 import * as BlocksSync from "../blocks/sync.js";


### PR DESCRIPTION
Once the local instance falls behind by a few days it takes prohibitively long to catch up again when running `analyze_blocks`.

For development purposes I added a script that does not attempt to sync all the way to the current head but only analyzes a fixed number of blocks beginning from the current chain head. 

